### PR TITLE
Add previous sprints section

### DIFF
--- a/Previous-Sprints/Example-Month-Day-Year/README.md
+++ b/Previous-Sprints/Example-Month-Day-Year/README.md
@@ -1,0 +1,38 @@
+```
+Client: Example Client
+Office: Atlantis
+Designer(s): Jony Ive
+Date: 8.21.84
+Trello Board: https://trello.com/
+```
+
+## Context
+This is general context about the sprint, the project, and the client. Any outside constraints on the project?
+
+## Phase 1 - Understand
+Specifics about the first phase of the sprint
+
+[img of critical path]
+
+## Phase 2 - Diverge
+
+[Problem Statement]
+
+Specifics about the second phase of the sprint
+
+## Phase 3 - Converge
+Specifics about the third phase of the sprint
+
+## Phase 4 - Prototype
+Specifics about the fourth phase of the sprint
+
+[img of prototype]
+
+## Phase 5 - Test & Validate
+Specifics about the fifth phase of the sprint
+
+## What Worked?
+Tell your fellow designers what worked
+
+## What Didn't Work?
+Tell your fellow designers what didn't work so well

--- a/Previous-Sprints/README.md
+++ b/Previous-Sprints/README.md
@@ -1,0 +1,9 @@
+## Previous Sprints
+
+Our sprint process is tailored to each client and will likely evolve over time. Toward that end, we want to document sprints and identify success factors at each phase and the structuring of the overall sprint.
+
+Here is a living list of previous sprints. After running a design sprint, feel free to add a retrospective on your sprint using the example README.md – the PR process allows for other designer to review as well:
+
+======
+
+[Example Project](Example-Month-Day-Year): *Month, Year - Jony Ive*

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ project is only meant to be a set of guidelines and suggestions for a design
 sprint and not necessarily followed exactly. Each sprint should be tailored to
 the individual project and problem to be solved.
 
+Documentation from previous design sprints, including notes from each phase and what did and didn't work well, can be found in the [Previous Sprints](Previous-Sprints) folder.
+
 ## What is a Design Sprint?
 
 A design sprint is about quickly and collaboratively using design thinking to


### PR DESCRIPTION
There is significant value in hearing what people are omitting or adding to each sprint, where people are finding success across locations and sprints, and how their tailoring for sprints to particular clients. 

This adds and an index at the root of the repo ("/previous_sprints") where is each sprint can break down their particular process, what worked, and what didn't and have something of a documented retro at the end of the sprint.
