### PR TITLE
'mind maps' -> 'mind mapping'

### DIFF
--- a/2-Diverge/Schedule.md
+++ b/2-Diverge/Schedule.md
@@ -20,7 +20,7 @@ if necessary for the purpose of the iteration exercises.
 
 ### Diverge Cycle *(2 hours)*
 
-* [Mind Map](../Exercises/mind-maps.md) *(15min)*
+* [Mind Mapping](../Exercises/mind-mapping.md) *(15min)*
 * [Crazy Eights](../Exercises/crazy-eights.md) *(5min)*
 * [Storyboard](../Exercises/storyboards.md) *(20min)*
 * [Silent critique](../Exercises/silent-critique.md) *(10min)*

--- a/Exercises/3-12-3.md
+++ b/Exercises/3-12-3.md
@@ -22,7 +22,7 @@ This game is adapted from
 ## Instructions
 
 1. For the first 3 minutes, open individual brainstorming. This can take the form
-of [Mind Maps](mind-maps.md) or [Crazy Eights](crazy-eights.md).
+of [Mind Mapping](mind-mapping.md) or [Crazy Eights](crazy-eights.md).
 * Split everyone up into groups of 2 or 3. Give each group an Easel Pad so they
 can draw their UI large enough for the room to see.
 * For 12 minutes, let the group share their ideas they came up with in Step 1. Then they should converge in on one idea that they believe is the best and draw it on the Easel Pad.

--- a/Exercises/crazy-eights.md
+++ b/Exercises/crazy-eights.md
@@ -15,7 +15,7 @@ ideas quickly.
 
 They are part of the [Google Ventures Diverge](http://www.gv.com/lib/the-product-design-sprint-divergeday2)
 day cycle along with 
-[Mind Maps](mind-maps.md),
+[Mind Mapping](mind-mapping.md),
 [Storyboards](storyboards.md),
 [Silent Critique](silent-critique.md).
 

--- a/Exercises/silent-critique.md
+++ b/Exercises/silent-critique.md
@@ -17,7 +17,7 @@ so that each person isn't presenting each of their own ideas.
 They are part of the [Google Ventures
 Diverge](http://www.gv.com/lib/the-product-design-sprint-divergeday2)
 day cycle along with
-[Mind Maps](mind-maps.md),
+[Mind Mapping](mind-mapping.md),
 [Crazy Eights](crazy-eights.md), and
 [Storyboards](storyboards.md).
 

--- a/Exercises/storyboards.md
+++ b/Exercises/storyboards.md
@@ -31,7 +31,7 @@ and put 3 sticky notes
 going down the side of the page.
 2. Choose an idea that you had previously from another exercise 
 like [Mind Mapping](mind-mapping.md)
-or [Crazy Eights](Crazy Eights)
+or [Crazy Eights](crazy-eights.md)
 to put more thought and detail into.
 2. Each sticky note is one frame in the storyboard.
 The sticky note should be

--- a/Exercises/storyboards.md
+++ b/Exercises/storyboards.md
@@ -14,7 +14,7 @@ dive into details of the interaction.
 They are part of the [Google Ventures
 Diverge](http://www.gv.com/lib/the-product-design-sprint-divergeday2)
 day cycle along with
-[Mind Maps](mind-maps.md),
+[Mind Mapping](mind-mapping.md),
 [Crazy Eights](crazy-eights.md),
 [Silent Critique](silent-critique.md).
 
@@ -30,7 +30,7 @@ From [The product design sprint: diverge (day 2)](http://www.gv.com/lib/the-prod
 and put 3 sticky notes
 going down the side of the page.
 2. Choose an idea that you had previously from another exercise 
-like [Mind Maps](mind-maps.md)
+like [Mind Mapping](mind-mapping.md)
 or [Crazy Eights](Crazy Eights)
 to put more thought and detail into.
 2. Each sticky note is one frame in the storyboard.


### PR DESCRIPTION
I noticed a dead link to `mind-maps.md`, and noticed it had been moved to `mind-mapping.md`. 

So this commit fixes those links (both their text and href)